### PR TITLE
ゲームの収録環境を図で整理する

### DIFF
--- a/config/recording/video_game.md
+++ b/config/recording/video_game.md
@@ -1,0 +1,68 @@
+# ゲーム収録環境
+
+## 2022-08-07..
+
+### 電源供給
+
+```mermaid
+flowchart LR
+  電源 --> Switch
+  電源 --> 外部ディスプレイ
+  電源 --> M1_MacBook_Air
+  Switch -- USB給電 --> Proコン
+  M1_MacBook_Air -- USB給電 --> HD60_S+
+  M1_MacBook_Air -- USB給電 --> Blue_Yeti
+```
+
+### 操作入力と映像出力
+
+```mermaid
+flowchart LR
+  hands[fa:fa-hands My Hands] --> Proコン 
+  Proコン -- Bluetooth or USB --> Switch
+  Switch -- HDMI --> HD60_S+
+  HD60_S+  -- HDMI --> 外部ディスプレイ
+  HD60_S+  -- USB --> M1_MacBook_Air
+  subgraph M1_MacBook_Air
+    subgraph OBS_Studio
+      映像キャプチャデバイス --> スクリーン
+    end
+  end
+  外部ディスプレイ --> eyes[fa:fa-eyes My Eyes]
+```
+
+### 音声入出力
+
+```mermaid
+flowchart LR
+  Switch -- HDMI --> HD60_S+
+  HD60_S+  -- HDMI --> 外部ディスプレイ
+  HD60_S+  -- USB --> M1_MacBook_Air
+  voice[fa:fa-waveform My Voice] --> Blue_Yeti
+  Blue_Yeti  -- USB --> M1_MacBook_Air
+
+  HD60_S+ -.-> Switch音声
+  Blue_Yeti -.-> 外部マイク音声
+
+  subgraph M1_MacBook_Air
+    Switch音声 --> 入力2
+    外部マイク音声
+
+    subgraph BlackHole
+      BlackHole_2ch
+    end
+
+    subgraph LadioCast
+      入力2 --> 出力Aux1
+      出力Aux1 --> BlackHole_2ch
+    end
+
+    外部マイク音声 --> マイク
+    subgraph OBS_Studio
+      マイク
+      BlackHole_2ch --> デスクトップ音声
+    end
+  end
+  
+  外部ディスプレイ --> ears[fa:fa-ear My Ears]
+```


### PR DESCRIPTION
[Switchのゲーム画面と音声を収録する \- tanaken0515](https://scrapbox.io/tanaken0515/Switch%E3%81%AE%E3%82%B2%E3%83%BC%E3%83%A0%E7%94%BB%E9%9D%A2%E3%81%A8%E9%9F%B3%E5%A3%B0%E3%82%92%E5%8F%8E%E9%8C%B2%E3%81%99%E3%82%8B)で構築したゲーム収録環境を図で整理しておきます。

---

図で整理しようという着想はこちらの記事の、↓の図から得ました。筆者の[ゆう](https://ha-labo.net/author/yuht/)さんありがとうございます。
[\[MacとOBS\]Discord・ブラウザの音・自分の声をまとめて録音したい（画像で解説つき） \| ひとりアソビラボ](https://ha-labo.net/obsmacsetting/)
> <img src="https://ha-labo.net/blog/wp-content/uploads/2021/03/obs-image.png">

---

Mermaidのフローチャート https://mermaid-js.github.io/mermaid/#/flowchart を使って簡単に図が書けて便利でした。Mermaidさんありがとう。